### PR TITLE
refactor: make transactions more concise

### DIFF
--- a/lib/stone_banking_api/accounts/banking_accounts.ex
+++ b/lib/stone_banking_api/accounts/banking_accounts.ex
@@ -2,6 +2,7 @@ defmodule StoneBankingAPI.Accounts.BankingAccounts do
   @moduledoc """
   Database queries for handling the update of banking accounts.
   """
+  import Ecto.Query, only: [from: 2]
   alias Ecto.Multi
   alias StoneBankingAPI.Repo
   alias StoneBankingAPI.Accounts.Schemas.BankingAccount
@@ -13,11 +14,17 @@ defmodule StoneBankingAPI.Accounts.BankingAccounts do
     |> Multi.run(:get_account, fn repo, _changes ->
       get_account(repo, id)
     end)
-    |> Multi.run(:do_withdrawn, fn repo, %{get_account: account} ->
-      do_withdrawn(repo, account, value)
-    end)
+    |> Multi.update_all(
+      :do_withdrawn,
+      fn %{get_account: account} ->
+        withdrawn_query(account, value)
+      end,
+      []
+    )
     |> Repo.transaction()
     |> handle_multi()
+  rescue
+    Postgrex.Error -> {:error, :balance_must_be_positive}
   end
 
   defp get_account(repo, id) do
@@ -27,18 +34,21 @@ defmodule StoneBankingAPI.Accounts.BankingAccounts do
     end
   end
 
-  defp do_withdrawn(repo, account, value) do
-    params = %{balance: account.balance - value}
+  defp withdrawn_query(account, value) do
+    value = value * -1
 
-    BankingAccount.changeset(account, params)
-    |> repo.update()
+    from(b in BankingAccount,
+      where: b.id == ^account.id,
+      update: [inc: [balance: ^value]],
+      select: b
+    )
   end
 
   defp handle_multi({:error, _failed_operation, changeset, _changes_so_far}) do
     {:error, changeset}
   end
 
-  defp handle_multi({:ok, %{do_withdrawn: account}}) do
+  defp handle_multi({:ok, %{do_withdrawn: {_, [account]}}}) do
     Email.notify_withdrawal(account)
     {:ok, account}
   end

--- a/test/stone_banking_api/accounts_withdrawn_test.exs
+++ b/test/stone_banking_api/accounts_withdrawn_test.exs
@@ -25,10 +25,8 @@ defmodule StoneBankingAPI.AccountsWithdrawnTest do
     end
 
     test "will not allow overwithdrawals", ctx do
-      assert {:error, changeset} =
+      assert {:error, :balance_must_be_positive} =
                BankingAccounts.withdrawn(%Withdrawn{account_id: ctx.account_id, value: 200_000})
-
-      assert %{balance: ["must be greater than or equal to 0"]} == errors_on(changeset)
     end
   end
 end


### PR DESCRIPTION
Withdrawn operation now uses update_all and increment operations for handling concurrent requests (this was done only as a learning experience).

Transfers between accounts is a less verbose module.